### PR TITLE
ci: Use signcl/docusaurus-prince-pdf to generate pdf version of the book

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -9,11 +9,9 @@ on:
       - master
 
 jobs:
-  deploy:
-    name: Build and Deploy
+  build:
+    name: Build
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -24,6 +22,24 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-output
+          path: build/
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-output
+          path: build/
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.ref == 'refs/heads/master' }}
@@ -33,3 +49,36 @@ jobs:
           publish_dir: ./build
           user_name: jwalton
           user_email: dev@lucid.thedreaming.org
+
+  pdf:
+    name: Generate PDF Version
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-output
+          path: build/
+      - name: Install Prince (HTML to PDF converter)
+        run: |
+          curl https://www.princexml.com/download/prince-14.2-linux-generic-x86_64.tar.gz -O
+          tar zxf prince-14.2-linux-generic-x86_64.tar.gz
+          cd prince-14.2-linux-generic-x86_64
+          yes "" | sudo ./install.sh
+      - name: Start Server and Build PDF
+        run: |
+          # Symlink to make docusaurus `baseUrl` working
+          ln -s ./build rust-book-abridged
+          # Start local server and wait for it to be ready
+          npx serve . -p 1337 & npx wait-on http://localhost:1337/rust-book-abridged
+          # Generate PDF
+          npx docusaurus-prince-pdf -u http://localhost:1337/rust-book-abridged --output rust-book-abridged.pdf
+          # Kill server
+          fuser -k 1337/tcp 
+      - name: Upload PDF Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: rust-book-abridged.pdf
+          path: rust-book-abridged.pdf
+          if-no-files-found: error

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -28,3 +28,11 @@
   --ifm-color-primary-lightest: #ffb3b3;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
+
+/* This works around the issue of truncated code-blocks in https://github.com/signcl/docusaurus-prince-pdf/ */
+@media print {
+  code[class*='codeBlockLines'] {
+    float: none;
+    display: block;
+  }
+}


### PR DESCRIPTION
It currently produces a PDF as a build artifact (see https://github.com/kamilogorek/rust-book-abridged/actions/runs/4809589251 as an example), but can be moved anywhere and linked to from the main page.

Example PDF generated from current `master` branch: [rust-book-abridged.pdf](https://github.com/jwalton/rust-book-abridged/files/11333758/rust-book-abridged.pdf)

All bookmarks are generated correctly based on Docusaurus ToC: 

<img width="128" alt="image" src="https://user-images.githubusercontent.com/1523305/234601930-7c04df1a-2a02-4183-81a0-ef039a146959.png">

I leave font size and the rest of the "visual feel" up to you :)

Thanks for the book!
