### PR TITLE
Minor fixes/typos

### DIFF
--- a/docs/ch03-common-programming-concepts.md
+++ b/docs/ch03-common-programming-concepts.md
@@ -344,7 +344,7 @@ let x = loop {
 // while loop in every other language.
 let mut number = 0;
 while number < 10 {
-    number++;
+    number += 1;
 }
 ```
 
@@ -358,7 +358,7 @@ for element in a {
 }
 
 // Count from 1 to 5
-for element in (1..6) {
+for element in 1..6 {
     println!("value is {element}");
 }
 ```

--- a/docs/ch05-structs.md
+++ b/docs/ch05-structs.md
@@ -30,7 +30,7 @@ fn main() {
 
     // Variable must be declared as `mut` if we want to be
     // able to modify the structure.
-    myUser.email = String::from("other_email@example,com");
+    myUser.email = String::from("other_email@example.com");
 }
 ```
 


### PR DESCRIPTION
 o Chapter 3, ++ postfix operator doesn't exist in Rust
 o Chapter 3, parentheses are not needed
 o Chapter 5, example.com comma typo fix