### PR TITLE
fix(grammar-checks): small typo fixes

### DIFF
--- a/docs/ch02-guessing-game.md
+++ b/docs/ch02-guessing-game.md
@@ -31,7 +31,7 @@ fn main() {
 
 You can run this with `cargo run`, and it should ask you to enter a value and then print out what you entered.
 
-In order to read user input, we're using the `io` library from the standard library, but to reference `io` more conveniently we bring it into _scope_. We do this with the first line, `use std::io`. This is a bit like an `import` statement in python or Java, but note that that don't need to explicitly import `io` to use it. We could remove the `use` line and replace `io::stdin()` with `std::io::stdin()`. There are a number of symbols that Rust brings into scope for you from the standard library automatically - things that get used in almost every program you're going to write. This set is called [the _prelude_](https://doc.rust-lang.org/stable/std/prelude/index.html).
+In order to read user input, we're using the `io` library from the standard library, but to reference `io` more conveniently we bring it into _scope_. We do this with the first line, `use std::io`. This is a bit like an `import` statement in python or Java, but note that don't need to explicitly import `io` to use it. We could remove the `use` line and replace `io::stdin()` with `std::io::stdin()`. There are a number of symbols that Rust brings into scope for you from the standard library automatically - things that get used in almost every program you're going to write. This set is called [the _prelude_](https://doc.rust-lang.org/stable/std/prelude/index.html).
 
 ## Storing Values with Variables
 

--- a/docs/ch03-common-programming-concepts.md
+++ b/docs/ch03-common-programming-concepts.md
@@ -31,7 +31,7 @@ Variables cannot be declared at the global scope [unless they are `static`](#sta
 
 :::info
 
-You may have noticed that that "mostly" above when we were talking about immutable variables. Immutability prevents us from directly modifying members of a struct, however in [chapter 15][chap15] we're going to find out that sometimes you can modify individual parts of an immutable struct through a concept call _interior mutability_. A mutex is an example of an object that is immutable, but you're allowed to change the value in it if you own the lock.
+You may have noticed that "mostly" above when we were talking about immutable variables. Immutability prevents us from directly modifying members of a struct, however in [chapter 15][chap15] we're going to find out that sometimes you can modify individual parts of an immutable struct through a concept call _interior mutability_. A mutex is an example of an object that is immutable, but you're allowed to change the value in it if you own the lock.
 
 :::
 

--- a/docs/ch07-packages-crates-modules.md
+++ b/docs/ch07-packages-crates-modules.md
@@ -30,7 +30,7 @@ A _module_ is quite similar to a package in Go, and is somewhat similar to a pac
 - In _src/garden.rs_.
 - In _src/garden/mod.rs_ (older style)
 
-Similarly modules can defined submodules. _src/garden.rs_ can have a `mod vegetables` that might be defined in _src/garden/vegetables.rs_ (note that garden's submodules go in a folder named "garden", not in the same folder).
+Similarly modules can define submodules. _src/garden.rs_ can have a `mod vegetables` that might be defined in _src/garden/vegetables.rs_ (note that garden's submodules go in a folder named "garden", not in the same folder).
 
 Note that we've marked the _src/garden/mod.rs_ version as "older style". This is still supported (and as we'll see in [chapter 11][chap11] it's very handy for writing integration tests) but the _src/garden.rs_ is the one you should use by default. If you try to use the mix the `[name].rs` and `[name]/mod.rs` styles in the same module, you'll get a compiler error.
 


### PR DESCRIPTION
- replace "that that" with "that"
- replace past tense "defined" with "define"